### PR TITLE
whitespace fix

### DIFF
--- a/percentile_norm.ipynb
+++ b/percentile_norm.ipynb
@@ -1,0 +1,163 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## TESTING THE MARKKICK206 EDIT"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading data...\n",
+      "Loading data complete.\n",
+      "Running percentile-normalization...\n",
+      "Running percentile-normalization complete.\n",
+      "Percentile-normalized data written to baxter_percentile_norm.txt\n"
+     ]
+    }
+   ],
+   "source": [
+    "!python percentile_norm.py -i baxter_crc_data.txt -case baxter_crc_samples.txt -control baxter_h_samples.txt -o baxter_percentile_norm.txt\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import csv\n",
+    "\n",
+    "## Iterate through our list and write each line to the file\n",
+    "def write_new_delim(sample_file, new_sample_file,delim=False):\n",
+    "    sample_file = csv.reader(open(sample_file),delimiter='\\t')\n",
+    "    new_sample_file = open(new_sample_file,'w')\n",
+    "    \n",
+    "    if (delim):\n",
+    "        for i in sample_file:\n",
+    "            new_sample_file.writelines('\\n'.join(i))\n",
+    "    else:\n",
+    "        for i in sample_file:\n",
+    "            new_sample_file.writelines(','.join(i))\n",
+    "            \n",
+    "    new_sample_file.close()\n",
+    "\n",
+    "def write_new_delim_files(control_samples, case_samples):\n",
+    "    write_new_delim(control_samples,'baxter_h_samples_newline.txt',True)\n",
+    "    write_new_delim(case_samples,'baxter_crc_samples_newline.txt',True)\n",
+    "    \n",
+    "    write_new_delim(control_samples,'baxter_h_samples.csv')\n",
+    "    write_new_delim(case_samples,'baxter_crc_samples.csv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "write_new_delim_files(\"baxter_h_samples.txt\",\"baxter_crc_samples.txt\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading data...\n",
+      "Loading data complete.\n",
+      "Running percentile-normalization...\n",
+      "Running percentile-normalization complete.\n",
+      "Percentile-normalized data written to baxter_percentile_norm_newline.txt\n"
+     ]
+    }
+   ],
+   "source": [
+    "!python percentile_norm.py -i baxter_crc_data.txt -sample-d newline -case baxter_crc_samples_newline.txt -control baxter_h_samples_newline.txt -o baxter_percentile_norm_newline.txt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading data...\n",
+      "Loading data complete.\n",
+      "Running percentile-normalization...\n",
+      "Running percentile-normalization complete.\n",
+      "Percentile-normalized data written to baxter_percentile_norm_csv.txt\n"
+     ]
+    }
+   ],
+   "source": [
+    "!python percentile_norm.py -i baxter_crc_data.txt -sample-d comma -case baxter_crc_samples.csv -control baxter_h_samples.csv -o baxter_percentile_norm_csv.txt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "## Everything looks good!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python [Root]",
+   "language": "python",
+   "name": "Python [Root]"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/percentile_norm.py
+++ b/percentile_norm.py
@@ -49,9 +49,9 @@ x = df.values
 
 # Read case and control samples as lists
 with open(args.case, 'r') as f:
-    case_list = f.read().split(seps[args.sample_d])
+    case_list = f.read().rstrip().split(seps[args.sample_d])
 with open(args.control, 'r') as f:
-    control_list = f.read().split(seps[args.sample_d])
+    control_list = f.read().rstrip().split(seps[args.sample_d])
 print('Loading data complete.')
 
 # Get control and case indices


### PR DESCRIPTION
simple fix to account for trailing whitespace in the case/control sample files.

Ipython notebook included to show all input files still work.

Can make this even more robust... but this may not be necessary in the current point of development.